### PR TITLE
fix(repository): use getter instead of a single collectionRef

### DIFF
--- a/lib/repository/firestore.repository.ts
+++ b/lib/repository/firestore.repository.ts
@@ -10,7 +10,6 @@ import { FirestoreDocument } from '../dto';
 import { WhereQuery } from './where.query';
 
 export class FirestoreRepository<T extends FirestoreDocument> {
-  private readonly collectionRef: CollectionReference<T>;
   private collectionOptions: CollectionMetadata<T>;
 
   constructor(
@@ -22,8 +21,13 @@ export class FirestoreRepository<T extends FirestoreDocument> {
       throw new CollectionNotDefinedError();
     }
     this.collectionOptions = collectionOptions;
+  }
 
-    this.collectionRef = this.firestore
+  /**
+   * collectionRef is a getter to avoid race conditions when using operations with the collectionReference
+   */
+  get collectionRef(): CollectionReference<T> {
+    return this.firestore
       .collection(this.collectionOptions.collectionPath)
       .withConverter(this.collectionOptions.converter);
   }


### PR DESCRIPTION
## Description

When using promises, we could see a race condition due to using `collectionRef` as a class property.

Now we're using a getter to get a new instance of the collection ref when using the repository.

## Type of change (select one)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Requirements (all must be selected for an approval)

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes. (if anyone has tips on how to test this, they are welcome!)
- [x] All new and existing tests passed.

## Optional (none need to be selected, but are really welcome)

- [ ] I have added one e2e test that covers my changes
- [ ] I have updated the documentation accordingly.
