### PR TITLE
refactor(repository): set method only returns a cat

### DIFF
--- a/lib/dto/repository-set.dto.ts
+++ b/lib/dto/repository-set.dto.ts
@@ -1,6 +1,0 @@
-import { FirestoreDocument } from './firestore-document.dto';
-
-export class RepositorySetDto<T extends FirestoreDocument> {
-  isNew: boolean;
-  data: T;
-}

--- a/lib/repository/firestore.repository.ts
+++ b/lib/repository/firestore.repository.ts
@@ -11,7 +11,6 @@ import { FirestoreDocument } from '../dto';
 import { WhereQuery } from './where.query';
 import { PageQuery } from './page.query';
 import { InvalidArgumentError } from '../errors/invalid-argument.error';
-import { RepositorySetDto } from '../dto/repository-set.dto';
 
 export class FirestoreRepository<T extends FirestoreDocument> {
   private collectionOptions: CollectionMetadata<T>;
@@ -51,7 +50,7 @@ export class FirestoreRepository<T extends FirestoreDocument> {
     };
   }
 
-  async set(document: T): Promise<RepositorySetDto<T>> {
+  async set(document: T): Promise<T> {
     const { id, ...object } = document;
 
     if (!id) {
@@ -59,22 +58,12 @@ export class FirestoreRepository<T extends FirestoreDocument> {
     }
 
     const docRef = this.collectionRef.doc(id);
-
-    const currentDocument = await docRef.get();
     const result = await docRef.set(object as T);
 
-    const isNew = !currentDocument.exists;
-
     return {
-      isNew,
-      data: {
-        ...document,
-        createTime: isNew
-          ? result.writeTime.toDate()
-          : currentDocument.createTime?.toDate(),
-        updateTime: result.writeTime.toDate(),
-        readTime: isNew ? undefined : currentDocument.readTime,
-      },
+      ...document,
+      createTime: result.writeTime.toDate(),
+      updateTime: result.writeTime.toDate(),
     };
   }
 

--- a/test/e2e/firestore.e2e-spec.ts
+++ b/test/e2e/firestore.e2e-spec.ts
@@ -156,13 +156,17 @@ describe('Firestore', () => {
     expect(updateResult.status).toBe(200);
 
     const updateBody = updateResult.body;
-    expect(updateBody.name).toEqual(newCatName);
-    expect(updateBody.age).toEqual(createDto.age);
-    expect(updateBody.breed).toEqual(createDto.breed);
-    expect(updateBody.createTime).toEqual(createBody.createTime);
-    expect(updateBody.updateTime).toBeDefined();
+    expect(updateBody).toStrictEqual({
+      id: catId,
+      name: newCatName,
+      age: createDto.age,
+      breed: createDto.breed,
+      createTime: expect.any(String),
+      updateTime: expect.any(String),
+    });
+
+    expect(updateBody.createTime).not.toEqual(createBody.createTime);
     expect(updateBody.updateTime).not.toEqual(createBody.createTime);
-    expect(updateBody.readTime).toBeDefined();
   });
 
   afterEach(async () => {

--- a/test/src/cats/cats.controller.ts
+++ b/test/src/cats/cats.controller.ts
@@ -47,9 +47,9 @@ export class CatsController {
     catDto.age = createCatDto.age;
     catDto.id = id;
 
-    const result = await this.catsService.set(catDto);
+    const { cat, isNew } = await this.catsService.set(catDto);
 
-    res.status(result.isNew ? 201 : 200).json(result.cat);
+    res.status(isNew ? 201 : 200).json(cat);
   }
 
   @Patch(':id')

--- a/test/src/cats/cats.service.ts
+++ b/test/src/cats/cats.service.ts
@@ -16,9 +16,11 @@ export class CatsService {
   }
 
   async set(cat: Cat): Promise<SetCatResponseDto> {
-    const { isNew, data } = await this.catRepository.set(cat);
+    const currentCat = await this.catRepository.findById(cat.id);
 
-    return new SetCatResponseDto(isNew, data);
+    const catSet = await this.catRepository.set(cat);
+
+    return new SetCatResponseDto(currentCat === null, catSet);
   }
 
   async update(cat: Partial<Cat>): Promise<Partial<Cat>> {


### PR DESCRIPTION
## Description

Change the repository's `set` method to return just a cat instead of the information of it being new or not along with the document.
<!-- If an issue is being solved, just add the issue here, like "Solves #1234" -->
<!-- If no issue is being solved, add a short description of the PR here -->

## Type of change (select one)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] CI configuration or features
- [ ] Build configuration
- [x] Refactor in existing code

## Requirements (all must be selected for an approval)

- [x] I have read the CONTRIBUTING document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Optional (none need to be selected, but are really welcome)

- [x] I have added one e2e test that covers my changes
- [ ] I have updated the documentation accordingly.
